### PR TITLE
Esc to esc melty

### DIFF
--- a/src/vs/workbench/browser/parts/melty/meltyActions.ts
+++ b/src/vs/workbench/browser/parts/melty/meltyActions.ts
@@ -3,6 +3,27 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { IMeltyService } from './meltyService';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 
+export class CloseMeltyAction extends Action2 {
+	static readonly ID = 'workbench.action.closeMelty';
+
+	constructor() {
+		super({
+			id: CloseMeltyAction.ID,
+			title: { value: 'Close Melty Popup', original: 'Close Melty Popup' },
+			f1: true,
+			keybinding: {
+				weight: 200,
+				primary: KeyCode.Escape,
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const meltyService = accessor.get(IMeltyService);
+		meltyService.close();
+	}
+}
+
 export class ToggleMeltyAction extends Action2 {
 	static readonly ID = 'workbench.action.toggleMelty';
 
@@ -25,3 +46,4 @@ export class ToggleMeltyAction extends Action2 {
 }
 
 registerAction2(ToggleMeltyAction);
+registerAction2(CloseMeltyAction);

--- a/src/vs/workbench/browser/parts/melty/meltyActions.ts
+++ b/src/vs/workbench/browser/parts/melty/meltyActions.ts
@@ -20,7 +20,7 @@ export class CloseMeltyAction extends Action2 {
 
 	run(accessor: ServicesAccessor): void {
 		const meltyService = accessor.get(IMeltyService);
-		meltyService.close();
+		meltyService.hide();
 	}
 }
 


### PR DESCRIPTION
Description by Melty:

This pull request introduces the following changes:

Implemented a new CloseMeltyAction to dismiss the Melty popup using the ESC key.
Refactored the dismissal method from meltyService.close() to meltyService.hide() in CloseMeltyAction for consistency.

These updates enhance user interaction by providing a standard keyboard shortcut for closing the Melty popup, improving overall usability and accessibility.