### PR TITLE
fix: match VSC version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melty-dev",
-  "version": "0.1.0",
+  "version": "1.94.0",
   "distro": "c0357b8e2d9b4097c8f05b64762247bbbd57ad77",
   "author": {
     "name": "Melty, Inc"


### PR DESCRIPTION
So extensions don't crash.