### PR TITLE
Allow users to either provide Anthropic key, OR use our proxy

### DIFF
--- a/extensions/spectacular/src/backend/claudeAPI.ts
+++ b/extensions/spectacular/src/backend/claudeAPI.ts
@@ -29,6 +29,7 @@ export async function streamClaude(
 	let baseURL = "https://melty-api.fly.dev/anthropic"
 
 	// If the user provides an API key, go direct to Claude, otherwise proxy to Melty
+	// TODO: abstract this logic away (it's repeated in commitMessageGenerator.ts)
 	if (apiKey) {
 		console.log("API KEY SET — DIRECT TO ANTHROPIC")
 		baseURL = "https://api.anthropic.com"

--- a/extensions/spectacular/src/backend/claudeAPI.ts
+++ b/extensions/spectacular/src/backend/claudeAPI.ts
@@ -25,16 +25,21 @@ export async function streamClaude(
 	}
 
 	const config = vscode.workspace.getConfiguration("melty");
-	const apiKey = config.get<string>("anthropicApiKey");
+	let apiKey = config.get<string>("anthropicApiKey");
+	let baseURL = "https://melty-api.fly.dev/anthropic"
 
-	if (!apiKey) {
-		throw new Error(
-			"Anthropic API key is not set. Please configure it in settings."
-		);
+	// If the user provides an API key, go direct to Claude, otherwise proxy to Melty
+	if (apiKey) {
+		console.log("API KEY SET — DIRECT TO ANTHROPIC")
+		baseURL = "https://api.anthropic.com"
+	} else {
+		console.log("NO API KEY — PROXYING")
+		apiKey = "dummyToken"
 	}
 
 	const anthropic = new Anthropic({
 		apiKey: apiKey,
+		baseURL: baseURL
 	});
 
 	try {

--- a/extensions/spectacular/src/backend/commitMessageGenerator.ts
+++ b/extensions/spectacular/src/backend/commitMessageGenerator.ts
@@ -6,16 +6,21 @@ export async function generateCommitMessage(
 	accompanyingMessage: string = ""
 ): Promise<string> {
 	const config = vscode.workspace.getConfiguration("melty");
-	const apiKey = config.get<string>("anthropicApiKey");
+	let apiKey = config.get<string>("anthropicApiKey");
+	let baseURL = "https://melty-api.fly.dev/anthropic"
 
-	if (!apiKey) {
-		throw new Error(
-			"Anthropic API key is not set. Please configure it in settings."
-		);
+	// If the user provgides an API key, go direct to Claude, otherwise proxy to Melty
+	if (apiKey) {
+		console.log("API KEY SET — DIRECT TO ANTHROPIC")
+		baseURL = "https://api.anthropic.com"
+	} else {
+		console.log("NO API KEY — PROXYING")
+		apiKey = "dummyToken"
 	}
 
 	const anthropic = new Anthropic({
 		apiKey: apiKey,
+		baseURL: baseURL
 	});
 
 	const prompt = `You are an expert software engineer.


### PR DESCRIPTION
At some point we should abstract this logic so we don't have to repeat it. I should probably ask Melty to do that huh.