### PR TITLE
Add required vsda features as defined in ./cli/src/tunnels/challenge.rs

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -82,3 +82,4 @@ codegen-units = 1
 [features]
 default = []
 vscode-encrypt = []
+vsda = []


### PR DESCRIPTION
Added vsda as a feature in Cargo.toml which is required in ./cli/src/tunnels/challenge.rs