### PR TITLE
Fix re-rendering of joules in conversation view

### DIFF
--- a/extensions/spectacular/src/HelloWorldPanel.ts
+++ b/extensions/spectacular/src/HelloWorldPanel.ts
@@ -336,7 +336,7 @@ export class HelloWorldPanel implements WebviewViewProvider {
 			// 	{ uri: newFolderUri }
 			// );
 
-			const openResult: any = await vscode.commands.executeCommand('vscode.openFolder', newFolderUri, false)
+			const openResult: any = await vscode.commands.executeCommand('vscode.openFolder', newFolderUri, false);
 			return openResult === undefined;
 		} else {
 			return false;

--- a/extensions/spectacular/webview-ui/src/components/ConversationView.tsx
+++ b/extensions/spectacular/webview-ui/src/components/ConversationView.tsx
@@ -15,7 +15,7 @@ import { RpcClient } from "@/RpcClient";
 import { JouleComponent } from "./JouleComponent";
 import * as strings from "@/utilities/strings";
 import { EventManager } from '@/eventManager';
-import { DehydratedTask } from "types";
+import { DehydratedTask, Joule } from "types";
 import { useNavigate } from "react-router-dom";
 
 import * as vscode from "vscode";
@@ -31,6 +31,8 @@ export function ConversationView() {
 	const [pickerOpen, setPickerOpen] = useState(false);
 	const isInitialRender = useRef(true);
 	const [task, setTask] = useState<DehydratedTask | null>(null);
+	// store and mutate the joules separately to avoid re-rendering
+	const [joules, setJoules] = useState<Joule[]>([]);
 	const [messageText, setMessageText] = useState("");
 	const conversationRef = useRef<HTMLDivElement>(null);
 	const [latestCommitHash, setLatestCommitHash] = useState<string | null>(null);
@@ -161,6 +163,27 @@ export function ConversationView() {
 			window.removeEventListener("keydown", handleKeyDown);
 		};
 	}, []);
+
+	useEffect(() => {
+		if (!task) {
+			return;
+		}
+
+		// prevents joule re-rendering
+		setJoules(ourJoules => {
+			if (ourJoules.length === 0) {
+				return [...task.conversation.joules]
+			} else if (ourJoules.length !== task.conversation.joules.length) {
+				const lastJoule = task.conversation.joules[task.conversation.joules.length - 1];
+				return [...ourJoules, lastJoule];
+			} else {
+				const lastJoule = task.conversation.joules[task.conversation.joules.length - 1];
+				const newJoules = ourJoules.slice(0, ourJoules.length - 1);
+				newJoules.push(lastJoule);
+				return newJoules;
+			}
+		});
+	}, [task]);
 
 	const updateTask = useCallback((task: DehydratedTask) => {
 		const lastJoule =
@@ -318,7 +341,7 @@ export function ConversationView() {
 				ref={conversationRef}
 			>
 				<div className="flex flex-col h-full">
-					{task?.conversation.joules.map((joule, index) => (
+					{joules.map((joule, index) => (
 						<MemoizedJouleComponent
 							key={index}
 							joule={joule}

--- a/extensions/spectacular/webview-ui/src/components/ConversationView.tsx
+++ b/extensions/spectacular/webview-ui/src/components/ConversationView.tsx
@@ -171,9 +171,9 @@ export function ConversationView() {
 
 		// prevents joule re-rendering
 		setJoules(ourJoules => {
-			if (ourJoules.length === 0) {
+			if (ourJoules.length === 0 || ourJoules.length > task.conversation.joules.length) {
 				return [...task.conversation.joules]
-			} else if (ourJoules.length !== task.conversation.joules.length) {
+			} else if (ourJoules.length < task.conversation.joules.length) {
 				const lastJoule = task.conversation.joules[task.conversation.joules.length - 1];
 				return [...ourJoules, lastJoule];
 			} else {


### PR DESCRIPTION
### What?
Fixes re-rendering of joules in the conversation view. Refer:

https://github.com/user-attachments/assets/1adfde4a-2ade-4f58-94ff-ab7ca5206964

### How?
By storing `joules` in a separate state variable, independent from the current task, we fix the re-rendering issue.

Note:
This is meant as a quick fix for this issue. Ideally, the electron process should not send the entire dehydrated task every time a token is received from claude. This is because most of the task still remains the same - only the last joule changes. But implementing that will require a significant change in the codebase and also in the #30 PR.

That is why this PR addresses the primary issue of constant renders of previous joules. Sending the entire task while streaming is another issue, which I will work on in a different PR, and after #30 gets merged.
