### PR TITLE
Constraint max height for textarea

### DIFF
--- a/extensions/spectacular/webview-ui/src/components/ConversationView.tsx
+++ b/extensions/spectacular/webview-ui/src/components/ConversationView.tsx
@@ -357,7 +357,7 @@ export function ConversationView() {
 						<AutoExpandingTextarea
 							placeholder="Talk to Melty"
 							id="message"
-							className="p-3 pr-12 pb-12 focus-visible:ring-1"
+							className="p-3 pr-12 pb-12 focus-visible:ring-1 max-h-[30vh] overflow-y-auto"
 							ref={inputRef}
 							required
 							value={messageText}

--- a/extensions/spectacular/webview-ui/src/components/Tasks.tsx
+++ b/extensions/spectacular/webview-ui/src/components/Tasks.tsx
@@ -354,7 +354,7 @@ export function Tasks({
 								value={messageText}
 								onChange={(e) => setMessageText(e.target.value)}
 								onKeyDown={handleKeyDown}
-								className="flex-grow p-3 pr-12 pb-12"
+								className="flex-grow p-3 pr-12 pb-12 max-h-[30vh] overflow-y-auto"
 								ref={textareaRef}
 								autoFocus={true}
 								required


### PR DESCRIPTION
### What?

Try to paste in a long piece of text in the textarea. You'll notice it occupies the entire screen.

This PR fixes this issue by setting the max height to `30vh`